### PR TITLE
Fix checkout v2 version

### DIFF
--- a/.github/workflows/dox.yml
+++ b/.github/workflows/dox.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container: beszedics/doxygen
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v2
       - run: make generate_documentation
       - name: Push git subdirectory as branch
         uses: s0/git-publish-subdir-action@v2.4.0


### PR DESCRIPTION
Az előző hotfix során az actionsben ezt a hibát kaptam: Error: fatal: unable to access 'https://github.com/Teaching-projects/SZE-MOSZE-2020-getTeamName/': server certificate verification failed. CAfile: none CRLfile: none

Ezért a dox.yml fájlban ~~- uses: actions/checkout@main~~ helyett - uses: actions/checkout@v2 -re módosítottam.