### PR TITLE
fix doxygen dockerfile

### DIFF
--- a/Docker/doxygen/Dockerfile
+++ b/Docker/doxygen/Dockerfile
@@ -4,5 +4,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 make \
 doxygen \
 graphviz \
-git=v2.16.3 \
+&& apt-get install -y git \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
A doxygen docker containerbe visszaírtam a legelső `&& apt-get install -y git \` sort, amiért először faild-et kaptunk, de most a damage branch masterbe mergelést követően egy gha rerun után sikeresen lefutott, ezért ezen a branchen kijavítottam ezt.

Előzmény: https://github.com/Teaching-projects/SZE-MOSZE-2020-getTeamName/issues/15